### PR TITLE
Review

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-all    :; DAPP_SOLC_OPTIMIZE=true DAPP_SOLC_OPTIMIZE_RUNS=200 SOLC_FLAGS="--optimize --optimize-runs=200" dapp --use solc:0.6.11 build
+all    :; DAPP_BUILD_OPTIMIZE=1 DAPP_BUILD_OPTIMIZE_RUNS=200 dapp --use solc:0.6.12 build
 clean  :; dapp clean
 test   :; ./test.sh
-deploy-kovan   :; DAPP_SOLC_OPTIMIZE=true DAPP_SOLC_OPTIMIZE_RUNS=200 SOLC_FLAGS="--optimize --optimize-runs=200" dapp --use solc:0.6.11 build && dapp create DssVest 0xAaF64BFCC32d0F15873a02163e7E500671a4ffcD
-deploy-mainnet :; DAPP_SOLC_OPTIMIZE=true DAPP_SOLC_OPTIMIZE_RUNS=200 SOLC_FLAGS="--optimize --optimize-runs=200" dapp --use solc:0.6.11 build && dapp create DssVest 0x9f8F72aA9304c8B593d555F12eF6589cC3A579A2
+deploy-kovan   :; make && dapp create DssVest 0xAaF64BFCC32d0F15873a02163e7E500671a4ffcD
+deploy-mainnet :; make && dapp create DssVest 0x9f8F72aA9304c8B593d555F12eF6589cC3A579A2

--- a/src/DssVest.sol
+++ b/src/DssVest.sol
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-pragma solidity ^0.6.11;
+pragma solidity 0.6.12;
 
 interface IMKR {
     function mint(address usr, uint256 amt) external;
@@ -67,6 +67,7 @@ contract DssVest {
     function init(address _usr, uint256 _amt, uint256 _tau, uint256 _pmt) external auth returns (uint256 id) {
         require(_usr != address(0),  "dss-vest/invalid-user");
         require(_amt < uint128(-1),  "dss-vest/amount-error");
+        require(_tau > 0,            "dss-vest/tau-zero");
         require(_tau < 5 * 365 days, "dss-vest/tau-too-long");
         require(_pmt < uint128(-1),  "dss-vest/payout-error");
         require(_pmt <= _amt,        "dss-vest/bulk-payment-higher-than-amt");
@@ -92,11 +93,11 @@ contract DssVest {
         require(_award.usr == msg.sender, "dss-vest/only-user-can-claim");
 
         if (block.timestamp >= _award.fin) {  // Vesting period has ended.
-            MKR.mint(_award.usr, sub(_award.amt, _award.rxd)); // TODO prove this can't fail. Look for remainder errors in formula below.
+            MKR.mint(_award.usr, sub(_award.amt, _award.rxd));
             delete awards[_id];
-        } else {                              // Vesting in progress
-            uint256 t = (block.timestamp - _award.bgn) * WAD / (_award.fin - _award.bgn);
-            uint256 mkr = (_award.amt * t) / WAD;
+        } else if (block.timestamp >= _award.bgn) {                              // Vesting in progress
+            uint256 t = (block.timestamp - _award.bgn) * WAD / (_award.fin - _award.bgn); // 0 <= t < WAD
+            uint256 mkr = (_award.amt * t) / WAD; // 0 <= mkr < _award.amt
             MKR.mint(_award.usr, sub(mkr, _award.rxd));
             awards[_id].rxd = uint128(mkr);
         }

--- a/src/DssVest.t.sol
+++ b/src/DssVest.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-pragma solidity ^0.6.7;
+pragma solidity 0.6.12;
 
 import "ds-test/test.sol";
 

--- a/test.sh
+++ b/test.sh
@@ -3,9 +3,7 @@ set -e
 
 [[ "$ETH_RPC_URL" && "$(seth chain)" == "ethlive" ]] || { echo "Please set a mainnet ETH_RPC_URL"; exit 1; }
 
-DAPP_SOLC_OPTIMIZE=true DAPP_SOLC_OPTIMIZE_RUNS=200 SOLC_FLAGS="--optimize --optimize-runs=200" dapp --use solc:0.6.11 build
+export DAPP_BUILD_OPTIMIZE=1
+export DAPP_BUILD_OPTIMIZE_RUNS=200
 
-export DAPP_TEST_TIMESTAMP=$(seth block latest timestamp)
-export DAPP_TEST_NUMBER=$(seth block latest number)
-
-LANG=C.UTF-8 hevm dapp-test --rpc="$ETH_RPC_URL" --json-file=out/dapp.sol.json --dapp-root=. --verbose 1
+dapp --use solc:0.6.12 test --rpc-url="$ETH_RPC_URL" -v


### PR DESCRIPTION
Looks good. Mostly minor / housekeeping updates, but there were two moderate errors. Notes:

 * Update to specific version 0.6.12 to align with the other repos
 * Update to new dapp tools cli arguments + simplified Makefile
 * _tau > 0 to prevent division by zero case in `vest()`
 * Add block.timestamp bound on `vest()` - I think miners enforce every block having a timestamp that is in the future, but best to be extra safe just in case
 * Added notes about the bounds of `t` and `mkr` to show no safe math is needed
 * Removed the TODO comment as it is safe