### PR TITLE
Allow for arbitrary start time

### DIFF
--- a/src/DssVest.sol
+++ b/src/DssVest.sol
@@ -64,19 +64,20 @@ contract DssVest {
         require((z = x - y) <= x);
     }
 
-    function init(address _usr, uint256 _amt, uint256 _tau, uint256 _pmt) external auth returns (uint256 id) {
-        require(_usr != address(0),  "dss-vest/invalid-user");
-        require(_amt < uint128(-1),  "dss-vest/amount-error");
-        require(_tau < 5 * 365 days, "dss-vest/tau-too-long");
-        require(_pmt < uint128(-1),  "dss-vest/payout-error");
-        require(_pmt <= _amt,        "dss-vest/bulk-payment-higher-than-amt");
+    function init(address _usr, uint256 _amt, uint256 _bgn, uint256 _tau, uint256 _pmt) external auth returns (uint256 id) {
+        require(_usr != address(0),                     "dss-vest/invalid-user");
+        require(_amt < uint128(-1),                     "dss-vest/amount-error");
+        require(_bgn < block.timestamp + 5 * 365 days,  "dss-vest/bgn-too-far");
+        require(_tau < 5 * 365 days,                    "dss-vest/tau-too-long");
+        require(_pmt < uint128(-1),                     "dss-vest/payout-error");
+        require(_pmt <= _amt,                           "dss-vest/bulk-payment-higher-than-amt");
 
         id = ++ids;
         if (_amt - _pmt != 0) {      // safe because pmt <= amt
             awards[id] = Award({
                 usr: _usr,
-                bgn: uint48(block.timestamp),
-                fin: uint48(block.timestamp + _tau),
+                bgn: uint48(_bgn),
+                fin: uint48(_bgn + _tau),
                 amt: uint128(_amt - _pmt),
                 rxd: 0
             });

--- a/src/DssVest.t.sol
+++ b/src/DssVest.t.sol
@@ -49,7 +49,7 @@ contract DssVestTest is DSTest {
     }
 
     function testInit() public {
-        vest.init(address(this), 100 * 10**18, 100 days, 0);
+        vest.init(address(this), 100 * 10**18, block.timestamp, 100 days, 0);
         (address usr, uint48 bgn, uint48 fin, uint128 amt, uint128 rxd) = vest.awards(1);
         assertEq(usr, address(this));
         assertEq(uint256(bgn), now);
@@ -59,12 +59,12 @@ contract DssVestTest is DSTest {
     }
 
     function testPmt() public {
-        vest.init(address(this), 100 * 10**18, 100 days, 10 * 10**18);
+        vest.init(address(this), 100 * 10**18, block.timestamp, 100 days, 10 * 10**18);
         assertEq(Token(address(vest.MKR())).balanceOf(address(this)), 10*10**18);
     }
 
     function testVest() public {
-        uint256 id = vest.init(address(this), 100 * 10**18, 100 days, 0);
+        uint256 id = vest.init(address(this), 100 * 10**18, block.timestamp, 100 days, 0);
 
         hevm.warp(now + 10 days);
 
@@ -98,7 +98,7 @@ contract DssVestTest is DSTest {
     }
 
     function testVestAfterTimeout() public {
-        uint256 id = vest.init(address(this), 100 * 10**18, 100 days, 0);
+        uint256 id = vest.init(address(this), 100 * 10**18, block.timestamp, 100 days, 0);
 
         hevm.warp(now + 200 days);
 
@@ -123,7 +123,7 @@ contract DssVestTest is DSTest {
     }
 
     function testMove() public {
-        uint256 id = vest.init(address(this), 100 * 10**18, 100 days, 0);
+        uint256 id = vest.init(address(this), 100 * 10**18, block.timestamp, 100 days, 0);
         vest.move(id, address(3));
 
         (address usr,,,,) = vest.awards(id);
@@ -131,19 +131,19 @@ contract DssVestTest is DSTest {
     }
 
     function testFailMoveToZeroAddress() public {
-        uint256 id = vest.init(address(this), 100 * 10**18, 100 days, 0);
+        uint256 id = vest.init(address(this), 100 * 10**18, block.timestamp, 100 days, 0);
         vest.move(id, address(0));
     }
 
     function testYank() public {
-        uint256 id = vest.init(address(this), 100 * 10**18, 100 days, 0);
+        uint256 id = vest.init(address(this), 100 * 10**18, block.timestamp, 100 days, 0);
         assertTrue(vest.live(id));
         vest.yank(id);
         assertTrue(!vest.live(id));
     }
 
     function testLive() public {
-        uint256 id = vest.init(address(this), 100 * 10**18, 100 days, 0);
+        uint256 id = vest.init(address(this), 100 * 10**18, block.timestamp, 100 days, 0);
         assertTrue(vest.live(id));
         assertTrue(!vest.live(5));
     }


### PR DESCRIPTION
The start time should not be contingent on when the spell gets executed imo.